### PR TITLE
Support multiple tags on middleware

### DIFF
--- a/Tests/DependencyInjection/Compiler/Builder/DefinitionBuilderTest.php
+++ b/Tests/DependencyInjection/Compiler/Builder/DefinitionBuilderTest.php
@@ -40,7 +40,8 @@ class DefinitionBuilderTest extends \PHPUnit_Framework_TestCase
         $container = $this->prophesize(ContainerBuilder::class);
 
         $middleware = ['test_middleware' => [
-           ['method' => 'attach']
+           ['method' => 'attach'],
+           ['method' => 'attach2'],
         ]];
 
         $handler = $this->subject->getHandlerDefinition($container->reveal(), $clientName, $middleware);
@@ -51,7 +52,7 @@ class DefinitionBuilderTest extends \PHPUnit_Framework_TestCase
 
         $methodCalls = $handler->getMethodCalls();
         // Count is the number of the given middleware + the default event and log middleware expressions
-        $this->assertCount(3, $methodCalls);
+        $this->assertCount(4, $methodCalls);
 
         $customMiddlewareCall = array_shift($methodCalls);
         $this->assertSame('push', array_shift($customMiddlewareCall));
@@ -60,6 +61,14 @@ class DefinitionBuilderTest extends \PHPUnit_Framework_TestCase
         $customMiddlewareExpression = array_shift($customMiddlewareExpressions);
         $this->assertInstanceOf(Expression::class, $customMiddlewareExpression);
         $this->assertSame('service("test_middleware").attach()', $customMiddlewareExpression->__toString());
+
+        $customMiddlewareCall = array_shift($methodCalls);
+        $this->assertSame('push', array_shift($customMiddlewareCall));
+        /** @var Expression[] $customMiddlewareExpressions */
+        $customMiddlewareExpressions = array_shift($customMiddlewareCall);
+        $customMiddlewareExpression = array_shift($customMiddlewareExpressions);
+        $this->assertInstanceOf(Expression::class, $customMiddlewareExpression);
+        $this->assertSame('service("test_middleware").attach2()', $customMiddlewareExpression->__toString());
 
         $logMiddlewareCall = array_shift($methodCalls);
         $this->assertSame('push', array_shift($logMiddlewareCall));

--- a/Tests/DependencyInjection/Compiler/Filter/MiddlewareFilterTest.php
+++ b/Tests/DependencyInjection/Compiler/Filter/MiddlewareFilterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Mapudo\Bundle\GuzzleBundle\Tests\DependencyInjection\Compiler\Filter;
 
 use Mapudo\Bundle\GuzzleBundle\DependencyInjection\Compiler\Filter\MiddlewareFilter;
@@ -31,9 +32,9 @@ class MiddlewareFilterTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider dataProviderFilter
      *
-     * @param array  $middleware
+     * @param array $middleware
      * @param string $clientName
-     * @param array  $expectedResult
+     * @param array $expectedResult
      */
     public function testFilter(array $middleware, string $clientName, array $expectedResult)
     {
@@ -63,7 +64,37 @@ class MiddlewareFilterTest extends \PHPUnit_Framework_TestCase
         }
 
         return [
-            [$middleware, 'test_client', $middleware],
+            [
+                $middleware,
+                'test_client',
+                [
+                    'guzzle.middleware.stuff' => [
+                        [
+                            'name' => 'guzzle.middleware',
+                            'method' => 'addMiddlewareStuff',
+                            'client' => 'test_client'
+                        ],
+                        [
+                            'name' => 'guzzle.middleware',
+                            'method' => 'addOtherMiddlewareStuff',
+                            'client' => 'test_client'
+                        ]
+                    ]
+                ]
+            ],
+            [
+                $middleware,
+                'test_client2',
+                [
+                    'guzzle.middleware.stuff' => [
+                        [
+                            'name' => 'guzzle.middleware',
+                            'method' => 'addMiddlewareStuff',
+                            'client' => 'test_client2'
+                        ]
+                    ]
+                ]
+            ],
             [$middleware, 'false_client', []],
         ];
     }

--- a/Tests/DependencyInjection/Compiler/Filter/MiddlewareFilterTest.php
+++ b/Tests/DependencyInjection/Compiler/Filter/MiddlewareFilterTest.php
@@ -55,7 +55,7 @@ class MiddlewareFilterTest extends \PHPUnit_Framework_TestCase
     public function dataProviderFilter(): array
     {
         $parsedMiddleware = Yaml::parse(
-            file_get_contents(__DIR__ . '/../../../Resources/config/sample_middleware.yml')
+            file_get_contents(__DIR__ . '/../../../Resources/config/sample_multiple_middleware.yml')
         )['services'];
 
         $middleware = [];

--- a/Tests/Resources/config/sample_config.yml
+++ b/Tests/Resources/config/sample_config.yml
@@ -33,3 +33,5 @@ guzzle:
                 verify: true
                 timeout: 5
                 version: 1.1
+        test_client2:
+            base_uri: 'https://example.com/path'

--- a/Tests/Resources/config/sample_config.yml
+++ b/Tests/Resources/config/sample_config.yml
@@ -33,5 +33,3 @@ guzzle:
                 verify: true
                 timeout: 5
                 version: 1.1
-        test_client2:
-            base_uri: 'https://example.com/path'

--- a/Tests/Resources/config/sample_middleware.yml
+++ b/Tests/Resources/config/sample_middleware.yml
@@ -3,4 +3,6 @@ services:
     guzzle.middleware.stuff:
         tags:
             - { name: guzzle.middleware, method: addMiddlewareStuff, client: test_client }
+            - { name: guzzle.middleware, method: addOtherMiddlewareStuff, client: test_client }
+            - { name: guzzle.middleware, method: addMiddlewareStuff, client: test_client2 }
 

--- a/Tests/Resources/config/sample_multiple_middleware.yml
+++ b/Tests/Resources/config/sample_multiple_middleware.yml
@@ -3,3 +3,6 @@ services:
     guzzle.middleware.stuff:
         tags:
             - { name: guzzle.middleware, method: addMiddlewareStuff, client: test_client }
+            - { name: guzzle.middleware, method: addOtherMiddlewareStuff, client: test_client }
+            - { name: guzzle.middleware, method: addMiddlewareStuff, client: test_client2 }
+

--- a/src/DependencyInjection/Compiler/Builder/DefinitionBuilder.php
+++ b/src/DependencyInjection/Compiler/Builder/DefinitionBuilder.php
@@ -35,14 +35,14 @@ class DefinitionBuilder
         $handler->setFactory(['%guzzle_http.handler_stack.class%', 'create']);
 
         foreach ($middleware as $id => $tags) {
-            $attributes = reset($tags);
-
-            if (!empty($attributes['method'])) {
-                $middlewareExpression = new Expression(sprintf('service("%s").%s()', $id, $attributes['method']));
-            } else {
-                $middlewareExpression = new Expression(sprintf('service("%s")', $id));
+            foreach ($tags as $attributes) {
+                if (!empty($attributes['method'])) {
+                    $middlewareExpression = new Expression(sprintf('service("%s").%s()', $id, $attributes['method']));
+                } else {
+                    $middlewareExpression = new Expression(sprintf('service("%s")', $id));
+                }
+                $handler->addMethodCall('push', [$middlewareExpression]);
             }
-            $handler->addMethodCall('push', [$middlewareExpression]);
         }
 
         $eventServiceName = sprintf('guzzle_bundle.middleware.event_dispatch.%s', $clientName);

--- a/src/DependencyInjection/Compiler/Filter/MiddlewareFilter.php
+++ b/src/DependencyInjection/Compiler/Filter/MiddlewareFilter.php
@@ -28,10 +28,16 @@ class MiddlewareFilter
      */
     public function filter(ContainerBuilder $container, string $clientName): array
     {
-        $middleware = $container->findTaggedServiceIds('guzzle.middleware');
-        return array_filter($middleware, function ($middleware) use ($clientName) {
-            $options = reset($middleware);
-            return !array_key_exists('client', $options) || $clientName === $options['client'];
-        });
+        $middleware = [];
+
+        foreach ($container->findTaggedServiceIds('guzzle.middleware') as $service => $tags) {
+            foreach ($tags as $options) {
+                if (!array_key_exists('client', $options) || $clientName === $options['client']) {
+                    $middleware[$service][] = $options;
+                }
+            }
+        }
+
+        return $middleware;
     }
 }


### PR DESCRIPTION
Currently, this bundle does not allow adding multiple tags to a middleware service.

This is required when the same middleware is used on multiple clients (but not all), and when the same service has multiple middleware (e.g. https://github.com/Sainsburys/guzzle-oauth2-plugin)

This pull request allows multiple tags.